### PR TITLE
upgrade v2.3

### DIFF
--- a/schemas/branch-property-listing.json
+++ b/schemas/branch-property-listing.json
@@ -3,7 +3,7 @@
    "title" : "listing/list",
    "type" : "object",
    "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/listing/list.json",
+   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/list.json",
    "properties" : {
       "branch_reference" : {
          "type" : "string",

--- a/schemas/branch-property-listing.json
+++ b/schemas/branch-property-listing.json
@@ -1,17 +1,19 @@
 {
-   "$schema" : "http://json-schema.org/draft-04/schema#",
-   "title" : "listing/list",
-   "type" : "object",
-   "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/list.json",
-   "properties" : {
-      "branch_reference" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-      }
-   },
-   "required" : [
-      "branch_reference"
-   ]
-}
-
+    "$schema" : "http://json-schema.org/draft-04/schema#",
+    "title" : "listing/list",
+    "type" : "object",
+    "additionalProperties" : false,
+    "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/list.json",
+    "properties" : {
+       "branch_reference" : {
+          "type" : "string",
+          "pattern" : "^\\S(|(.|\\n)*\\S)\\Z",
+          "maxLength": 127
+       }
+    },
+    "required" : [
+       "branch_reference"
+    ]
+ }
+ 
+ 

--- a/schemas/branch-update.json
+++ b/schemas/branch-update.json
@@ -3,7 +3,7 @@
    "title" : "branch/update",
    "type" : "object",
    "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/branch/update.json",
+   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/branch/update.json",
    "definitions" : {
       "coordinates" : {
          "type" : "object",

--- a/schemas/branch-update.json
+++ b/schemas/branch-update.json
@@ -1,178 +1,181 @@
-{
-   "$schema" : "http://json-schema.org/draft-04/schema#",
-   "title" : "branch/update",
-   "type" : "object",
-   "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/branch/update.json",
-   "definitions" : {
-      "coordinates" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "latitude" : {
-               "type" : "number",
-               "minimum" : -90,
-               "maximum" : 90
-            },
-            "longitude" : {
-               "type" : "number",
-               "minimum" : -180,
-               "maximum" : 180
-            }
-         },
-         "required" : [
-            "latitude",
-            "longitude"
-         ]
-      }
-   },
-   "properties" : {
-      "branch_name" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-      },
-      "branch_reference" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-      },
-      "email" : {
-         "type" : "string",
-         "pattern" : "@"
-      },
-      "location" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "property_number_or_name" : {
-               "type" : [
-                  "integer",
-                  "string"
-               ],
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "street_name" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "locality" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "town_or_city" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "county" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "postal_code" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "country_code" : {
-               "type" : "string",
-               "pattern" : "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
-            },
-            "coordinates" : {
-               "$ref" : "#/definitions/coordinates"
-            },
-            "paf_address" : {
-               "type" : "object",
-               "additionalProperties" : false,
-               "properties" : {
-                  "address_key" : {
-                     "type" : "string",
-                     "pattern" : "^[0-9]{8}$"
-                  },
-                  "organisation_key" : {
-                     "type" : "string",
-                     "pattern" : "^[0-9]{8}$"
-                  },
-                  "postcode_type" : {
-                     "enum" : [
-                        "L",
-                        "S"
-                     ]
-                  }
-               },
-               "required" : [
-                  "address_key",
-                  "organisation_key",
-                  "postcode_type"
-               ]
-            },
-            "paf_udprn" : {
-               "type" : "string",
-               "pattern" : "^[0-9]{8}$"
-            }
-         },
-         "required" : [
-            "town_or_city",
-            "country_code"
-         ],
-         "anyOf" : [
-            {
-               "required" : [
-                  "property_number_or_name"
-               ]
-            },
-            {
-               "required" : [
-                  "street_name"
-               ]
-            }
-         ]
-      },
-      "telephone": {
-         "type" : "string",
-         "pattern" : "[0-9]+"
-      },
-      "website" : {
-         "type" : "string",
-         "pattern" : "^[Hh][Tt][Tt][Pp][Ss]?://\\S+$"
-      }
-   },
-   "required" : [
-      "branch_reference",
-      "branch_name",
-      "location"
-   ],
-   "oneOf" : [
-      { "$ref" : "#/constraints/gb" },
-      { "$ref" : "#/constraints/overseas" }
-   ],
-   "constraints" : {
-      "gb" : {
-         "properties" : {
-            "location" : {
-               "properties" : {
-                  "country_code" : {
-                     "pattern" : "^GB"
-                  },
-                  "postal_code" : {
-                     "pattern" : "^[A-PR-UWYZ][A-HJ-Y]?[0-9][0-9A-HJKMNPR-Y]? [0-9][ABD-HJLNP-UW-Z]{2}$"
-                  }
-               },
-               "required" : [
-                  "postal_code"
-               ]
-            }
-         }
-      },
-      "overseas" : {
-         "properties" : {
-            "location" : {
-               "properties" : {
-                  "country_code" : {
-                     "not" : {
-                        "pattern" : "^GB"
-                     }
-                  }
-               }
-            }
-         }
-      }
-   }
-}
 
+{
+    "$schema" : "http://json-schema.org/draft-04/schema#",
+    "title" : "branch/update",
+    "type" : "object",
+    "additionalProperties" : false,
+    "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/branch/update.json",
+    "definitions" : {
+       "coordinates" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+             "latitude" : {
+                "type" : "number",
+                "minimum" : -90,
+                "maximum" : 90
+             },
+             "longitude" : {
+                "type" : "number",
+                "minimum" : -180,
+                "maximum" : 180
+             }
+          },
+          "required" : [
+             "latitude",
+             "longitude"
+          ]
+       }
+    },
+    "properties" : {
+       "branch_name" : {
+          "type" : "string",
+          "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+       },
+       "branch_reference" : {
+          "type" : "string",
+          "pattern" : "^\\S(|(.|\\n)*\\S)\\Z",
+          "maxLength": 127
+       },
+       "email" : {
+          "type" : "string",
+          "pattern" : "@"
+       },
+       "location" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+             "property_number_or_name" : {
+                "type" : [
+                   "integer",
+                   "string"
+                ],
+                "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+             },
+             "street_name" : {
+                "type" : "string",
+                "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+             },
+             "locality" : {
+                "type" : "string",
+                "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+             },
+             "town_or_city" : {
+                "type" : "string",
+                "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+             },
+             "county" : {
+                "type" : "string",
+                "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+             },
+             "postal_code" : {
+                "type" : "string",
+                "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+             },
+             "country_code" : {
+                "type" : "string",
+                "pattern" : "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
+             },
+             "coordinates" : {
+                "$ref" : "#/definitions/coordinates"
+             },
+             "paf_address" : {
+                "type" : "object",
+                "additionalProperties" : false,
+                "properties" : {
+                   "address_key" : {
+                      "type" : "string",
+                      "pattern" : "^[0-9]{8}$"
+                   },
+                   "organisation_key" : {
+                      "type" : "string",
+                      "pattern" : "^[0-9]{8}$"
+                   },
+                   "postcode_type" : {
+                      "enum" : [
+                         "L",
+                         "S"
+                      ]
+                   }
+                },
+                "required" : [
+                   "address_key",
+                   "organisation_key",
+                   "postcode_type"
+                ]
+             },
+             "paf_udprn" : {
+                "type" : "string",
+                "pattern" : "^[0-9]{8}$"
+             }
+          },
+          "required" : [
+             "town_or_city",
+             "country_code"
+          ],
+          "anyOf" : [
+             {
+                "required" : [
+                   "property_number_or_name"
+                ]
+             },
+             {
+                "required" : [
+                   "street_name"
+                ]
+             }
+          ]
+       },
+       "telephone": {
+          "type" : "string",
+          "pattern" : "[0-9]+"
+       },
+       "website" : {
+          "type" : "string",
+          "pattern" : "^[Hh][Tt][Tt][Pp][Ss]?://\\S+$"
+       }
+    },
+    "required" : [
+       "branch_reference",
+       "branch_name",
+       "location"
+    ],
+    "oneOf" : [
+       { "$ref" : "#/constraints/gb" },
+       { "$ref" : "#/constraints/overseas" }
+    ],
+    "constraints" : {
+       "gb" : {
+          "properties" : {
+             "location" : {
+                "properties" : {
+                   "country_code" : {
+                      "pattern" : "^GB"
+                   },
+                   "postal_code" : {
+                      "pattern" : "^[A-PR-UWYZ][A-HJ-Y]?[0-9][0-9A-HJKMNPR-Y]? [0-9][ABD-HJLNP-UW-Z]{2}$"
+                   }
+                },
+                "required" : [
+                   "postal_code"
+                ]
+             }
+          }
+       },
+       "overseas" : {
+          "properties" : {
+             "location" : {
+                "properties" : {
+                   "country_code" : {
+                      "not" : {
+                         "pattern" : "^GB"
+                      }
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+ 
+ 

--- a/schemas/remove-property.json
+++ b/schemas/remove-property.json
@@ -1,26 +1,28 @@
 {
-   "$schema" : "http://json-schema.org/draft-04/schema#",
-   "title" : "listing/delete",
-   "type" : "object",
-   "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/delete.json",
-   "properties" : {
-      "listing_reference" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-      },
-      "deletion_reason" : {
-         "enum" : [
-            "withdrawn",
-            "offer_accepted",
-            "exchanged",
-            "completed",
-            "let"
-         ]
-      }
-   },
-   "required" : [
-      "listing_reference"
-   ]
-}
-
+    "$schema" : "http://json-schema.org/draft-04/schema#",
+    "title" : "listing/delete",
+    "type" : "object",
+    "additionalProperties" : false,
+    "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/delete.json",
+    "properties" : {
+       "listing_reference" : {
+          "type" : "string",
+          "pattern" : "^\\S(|(.|\\n)*\\S)\\Z",
+          "maxLength": 127
+       },
+       "deletion_reason" : {
+          "enum" : [
+             "withdrawn",
+             "offer_accepted",
+             "exchanged",
+             "completed",
+             "let"
+          ]
+       }
+    },
+    "required" : [
+       "listing_reference"
+    ]
+ }
+ 
+ 

--- a/schemas/remove-property.json
+++ b/schemas/remove-property.json
@@ -3,7 +3,7 @@
    "title" : "listing/delete",
    "type" : "object",
    "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/listing/delete.json",
+   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/delete.json",
    "properties" : {
       "listing_reference" : {
          "type" : "string",

--- a/schemas/send-property.json
+++ b/schemas/send-property.json
@@ -3,7 +3,7 @@
    "title" : "listing/update",
    "type" : "object",
    "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/listing/update.json",
+   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/update.json",
    "definitions" : {
       "area" : {
          "type" : "object",

--- a/schemas/send-property.json
+++ b/schemas/send-property.json
@@ -1,1220 +1,1789 @@
 {
-   "$schema" : "http://json-schema.org/draft-04/schema#",
-   "title" : "listing/update",
-   "type" : "object",
-   "additionalProperties" : false,
-   "id" : "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/update.json",
-   "definitions" : {
-      "area" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "units" : {
-               "$ref" : "#/definitions/area_units"
-            },
-            "value" : {
-               "type" : "number",
-               "minimum" : 0,
-               "exclusiveMinimum" : true
-            }
-         },
-         "required" : [
-            "units",
-            "value"
-         ]
+"$schema": "http://json-schema.org/draft-04/schema#",
+"title": "listing/update",
+"type": "object",
+"additionalProperties": false,
+"id": "http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/update.json",
+"definitions": {
+  "area": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "units": {
+        "$ref": "#/definitions/area_units"
       },
-      "area_units" : {
-         "enum" : [
-            "sq_feet",
-            "sq_yards",
-            "sq_metres",
-            "acres",
-            "hectares"
-         ]
-      },
-      "coordinates" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "latitude" : {
-               "type" : "number",
-               "minimum" : -90,
-               "maximum" : 90
-            },
-            "longitude" : {
-               "type" : "number",
-               "minimum" : -180,
-               "maximum" : 180
-            }
-         },
-         "required" : [
-            "latitude",
-            "longitude"
-         ]
-      },
-      "datetime" : {
-         "type" : "string",
-         "pattern" : "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$"
-      },
-      "dimension" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "length" : {
-               "type" : "number",
-               "minimum" : 0,
-               "exclusiveMinimum" : true
-            },
-            "width" : {
-               "type" : "number",
-               "minimum" : 0,
-               "exclusiveMinimum" : true
-            },
-            "units" : {
-               "enum" : [
-                  "feet",
-                  "metres"
-               ]
-            }
-         },
-         "required" : [
-            "length",
-            "width",
-            "units"
-         ]
-      },
-      "frequencies" : {
-         "enum" : [
-            "per_person_per_week",
-            "per_week",
-            "per_month",
-            "per_quarter",
-            "per_year"
-         ]
-      },
-      "min_max_area" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "minProperties" : 1,
-         "properties" : {
-            "minimum" : {
-               "$ref" : "#/definitions/area"
-            },
-            "maximum" : {
-               "$ref" : "#/definitions/area"
-            }
-         }
-      },
-      "energy_rating" : {
-         "type" : "integer",
-         "minimum" : 1
+      "value": {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": true
       }
-   },
-   "properties" : {
-      "accessibility" : {
-         "type" : "boolean"
+    },
+    "required": [
+      "units",
+      "value"
+    ]
+  },
+  "area_units": {
+    "enum": [
+      "sq_feet",
+      "sq_yards",
+      "sq_metres",
+      "acres",
+      "hectares"
+    ]
+  },
+  "coordinates": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "latitude": {
+        "type": "number",
+        "minimum": -90,
+        "maximum": 90
       },
-      "administration_fees" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+      "longitude": {
+        "type": "number",
+        "minimum": -180,
+        "maximum": 180
+      }
+    },
+    "required": [
+      "latitude",
+      "longitude"
+    ]
+  },
+  "datetime": {
+    "type": "string",
+    "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$"
+  },
+  "dimension": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "length": {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": true
       },
-      "annual_business_rates" : {
-         "type" : "number",
-         "minimum" : 0,
-         "exclusiveMinimum" : true
+      "width": {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": true
       },
-      "areas" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "minProperties" : 1,
-         "properties" : {
-            "external" : {
-               "$ref" : "#/definitions/min_max_area"
-            },
-            "internal" : {
-               "$ref" : "#/definitions/min_max_area"
+      "units": {
+        "enum": [
+          "feet",
+          "metres"
+        ]
+      }
+    },
+    "required": [
+      "length",
+      "width",
+      "units"
+    ]
+  },
+  "coastal_erosion": {
+    "type": "boolean"
+  },
+  "flooding_risks": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "flooded_within_last_5_years": {
+          "type": "boolean"
+      },
+      "sources_of_flooding": {
+        "type": "array",
+        "items": {
+          "enum": [
+            "river",
+            "sea",
+            "groundwater",
+            "lake",
+            "reservoir",
+            "other"
+          ]
+        }
+      },
+      "flood_defenses_present": {
+        "type": "boolean"
+      }
+    },
+    "oneOf": [
+        {
+            "minProperties": 3,
+            "required": ["flooded_within_last_5_years", "sources_of_flooding", "flood_defenses_present"]
+        },
+        {
+            "maxProperties": 1,
+            "required": ["flooded_within_last_5_years"],
+            "properties": {
+                "flooded_within_last_5_years": {
+                    "type": "boolean",
+                    "enum": [false]
+                }
             }
-         }
-      },
-      "available_bedrooms" : {
-         "type" : "integer",
-         "minimum" : 1
-      },
-      "available_from_date" : {
-         "$ref" : "#/definitions/datetime"
-      },
-      "basement" : {
-         "type" : "boolean"
-      },
-      "bathrooms" : {
-         "type" : "integer",
-         "minimum" : 0
-      },
-      "bills_included" : {
-         "type" : "array",
-         "minItems" : 1,
-         "uniqueItems" : true,
-         "items" : {
-            "enum" : [
-               "electricity",
-               "gas",
-               "internet",
-               "satellite_cable_tv",
-               "telephone",
-               "tv_licence",
-               "water"
-            ]
-         }
-      },
-      "branch_reference" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-      },
-      "burglar_alarm" : {
-         "type" : "boolean"
-      },
-      "business_for_sale" : {
-         "type" : "boolean"
-      },
-      "buyer_incentives" : {
-         "type" : "array",
-         "minItems" : 1,
-         "uniqueItems" : true,
-         "items" : {
-            "enum" : [
-               "equity_loan",
-               "help_to_buy",
-               "mi_new_home",
-               "new_buy",
-               "part_buy_part_rent",
-               "shared_equity",
-               "shared_ownership"
-            ]
-         }
-      },
-      "category" : {
-         "enum" : [
-            "commercial",
-            "residential"
-         ]
-      },
-      "central_heating" : {
-         "enum" : [
-            "full",
-            "partial",
-            "none"
-         ]
-      },
-      "chain_free" : {
-         "type" : "boolean"
-      },
-      "commercial_use_classes" : {
-         "type" : "array",
-         "minItems" : 1,
-         "uniqueItems" : true,
-         "items" : {
-            "type" : "string",
-            "pattern" : "^(A[1-5]|B[128]|C([134]|2A?)|D[12]|sui_generis)$"
-         }
-      },
-      "connected_utilities" : {
-         "type" : "array",
-         "minItems" : 1,
-         "uniqueItems" : true,
-         "items" : {
-            "enum" : [
-               "electricity",
-               "fibre_optic",
-               "gas",
-               "satellite_cable_tv",
-               "telephone",
-               "water"
-            ]
-         }
-      },
-      "conservatory" : {
-         "type" : "boolean"
-      },
-      "construction_year" : {
-         "type" : "integer"
-      },
-      "content" : {
-         "type" : "array",
-         "minItems" : 1,
-         "items" : {
-            "type" : "object",
-            "additionalProperties" : false,
-            "properties" : {
-               "caption" : {
-                  "type" : "string",
-                  "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-               },
-               "type" : {
-                  "enum" : [
-                     "audio_tour",
-                     "brochure",
-                     "document",
-                     "epc_graph",
-                     "epc_report",
-                     "floor_plan",
-                     "home_pack",
-                     "image",
-                     "site_plan",
-                     "virtual_tour"
-                  ]
-               },
-               "url" : {
-                  "type" : "string",
-                  "pattern" : "^[Hh][Tt][Tt][Pp][Ss]?://\\S+$"
-               }
-            },
-            "required" : [
-               "type",
-               "url"
-            ]
-         }
-      },
-      "council_tax_band" : {
-         "type" : "string",
-         "enum" : [
-            "A",
-            "B",
-            "C",
-            "D",
-            "E",
-            "F",
-            "G",
-            "H",
-            "I"
-         ]
-      },
-      "decorative_condition" : {
-         "enum" : [
-            "excellent",
-            "good",
-            "average",
-            "needs_modernisation"
-         ]
-      },
-      "deposit" : {
-         "type" : "number",
-         "minimum" : 0,
-         "exclusiveMinimum" : true
-      },
-      "detailed_description" : {
-         "type" : "array",
-         "minItems" : 1,
-         "items" : {
-            "type" : "object",
-            "additionalProperties" : false,
-            "properties" : {
-               "dimensions" : {
-                  "oneOf" : [
-                     { "$ref" : "#/definitions/dimension" },
-                     {
-                        "type" : "string",
-                        "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-                     }
-                  ]
-               },
-               "heading" : {
-                  "type" : "string"
-               },
-               "text" : {
-                  "type" : "string"
-               }
-            },
-            "hint" : "In a 'detailed_description' entry, 'dimensions' requires that 'heading' is also set",
-            "dependencies" : {
-               "dimensions" : [
-                  "heading"
-               ]
-            },
-            "anyOf" : [
-               {
-                  "hint" : "'detailed_description' entries require at least one of 'heading' or 'text'",
-                  "required" : [
-                     "heading"
-                  ]
-               },
-               {
-                  "hint" : "'detailed_description' entries require at least one of 'heading' or 'text'",
-                  "required" : [
-                     "text"
-                  ]
-               }
-            ]
-         }
-      },
-      "display_address" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-      },
-      "double_glazing" : {
-         "type" : "boolean"
-      },
-      "epc_ratings" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "minProperties" : 1,
-         "properties" : {
-            "eer_current_rating" : {
-               "$ref" : "#/definitions/energy_rating"
-            },
-            "eer_potential_rating" : {
-               "$ref" : "#/definitions/energy_rating"
-            },
-            "eir_current_rating" : {
-               "$ref" : "#/definitions/energy_rating"
-            },
-            "eir_potential_rating" : {
-               "$ref" : "#/definitions/energy_rating"
+        },
+        {
+            "maxProperties": 1,
+            "required": ["flood_defenses_present"]
+        },
+        {
+            "maxProperties": 1,
+            "required": ["sources_of_flooding"]
+        },
+        {
+            "maxProperties": 2,
+            "required": ["flood_defenses_present", "sources_of_flooding"]
+        },
+        {
+            "maxProperties": 2,
+            "required": ["flooded_within_last_5_years", "sources_of_flooding"],
+            "properties": {
+                "flooded_within_last_5_years": {
+                    "type": "boolean",
+                    "enum": [false]
+                }
             }
-         }
-      },
-      "feature_list" : {
-         "type" : "array",
-         "minItems" : 1,
-         "items" : {
-            "type" : "string",
-            "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-         }
-      },
-      "fireplace" : {
-         "type" : "boolean"
-      },
-      "fishing_rights" : {
-         "type" : "boolean"
-      },
-      "floor_levels" : {
-         "type" : "array",
-         "minItems" : 1,
-         "uniqueItems" : true,
-         "items" : {
-            "oneOf" : [
-               {
-                  "type" : "integer",
-                  "minimum" : 1
-               },
-               {
-                  "type" : "string",
-                  "enum" : [
-                     "basement",
-                     "ground",
-                     "penthouse"
-                  ]
-               }
-            ]
-         }
-      },
-      "floors" : {
-         "type" : "integer",
-         "minimum" : 1
-      },
-      "furnished_state" : {
-         "enum" : [
-            "furnished",
-            "furnished_or_unfurnished",
-            "part_furnished",
-            "unfurnished"
-         ]
-      },
-      "google_street_view" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "coordinates" : {
-               "$ref" : "#/definitions/coordinates"
-            },
-            "heading" : {
-               "type" : "number",
-               "minimum" : 0,
-               "maximum" : 360
-            },
-            "pitch" : {
-               "type" : "number",
-               "minimum" : -90,
-               "maximum" : 90
+        },
+        {
+            "maxProperties": 2,
+            "required": ["flooded_within_last_5_years", "flood_defenses_present"],
+            "properties": {
+                "flooded_within_last_5_years": {
+                    "type": "boolean",
+                    "enum": [false]
+                }
             }
-         },
-         "required" : [
-            "coordinates",
-            "heading",
-            "pitch"
-         ]
+        }
+    ]
+  },
+  "frequencies": {
+    "enum": [
+      "per_person_per_week",
+      "per_week",
+      "per_month",
+      "per_quarter",
+      "per_year"
+    ]
+  },
+  "mining_risks": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "coalfields": {
+          "type": "boolean"
       },
-      "ground_rent" : {
-         "type" : "number",
-         "minimum" : 0,
-         "exclusiveMinimum" : true
+      "other_mining_activities": {
+          "type": "boolean"
+      }
+    }
+  },
+  "min_max_area": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "minimum": {
+        "$ref": "#/definitions/area"
       },
-      "gym" : {
-         "type" : "boolean"
+      "maximum": {
+        "$ref": "#/definitions/area"
+      }
+    }
+  },
+  "energy_rating": {
+    "type": "integer",
+    "minimum": 1
+  },
+  "restrictions": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "conservation_area": {
+        "type": "boolean"
       },
-      "lease_expiry" : {
-         "type" : "object",
-         "minProperties" : 1,
-         "maxProperties" : 1,
-         "additionalProperties" : false,
-         "properties" : {
-            "expiry_date" : {
-               "type" : "string",
-               "pattern" : "^([0-9]{4})(-[0-9][0-9]){0,2}$"
-            },
-            "years_remaining" : {
-               "type" : "integer",
-               "minimum" : 1
-            }
-         }
+      "lease_restrictions": {
+        "type": "boolean"
       },
-      "life_cycle_status" : {
-         "enum" : [
-            "available",
-            "under_offer",
-            "sold_subject_to_contract",
-            "sold",
-            "let_agreed",
-            "let"
-         ]
+      "listed_building": {
+        "type": "boolean"
       },
-      "listed_building_grade" : {
-         "enum" : [
-            "category_a",
-            "category_b",
-            "category_c",
-            "grade_a",
-            "grade_b",
-            "grade_b_plus",
-            "grade_one",
-            "grade_two",
-            "grade_two_star",
-            "locally_listed"
-         ]
+      "permitted_development": {
+        "type": "boolean"
       },
-      "listing_reference" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
+      "real_burdens": {
+        "type": "boolean"
       },
-      "location" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "property_number_or_name" : {
-               "type" : [
-                  "integer",
-                  "string"
-               ],
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "street_name" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "locality" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "town_or_city" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "county" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "postal_code" : {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            },
-            "country_code" : {
-               "type" : "string",
-               "pattern" : "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
-            },
-            "coordinates" : {
-               "$ref" : "#/definitions/coordinates"
-            },
-            "paf_address" : {
-               "type" : "object",
-               "additionalProperties" : false,
-               "properties" : {
-                  "address_key" : {
-                     "type" : "string",
-                     "pattern" : "^[0-9]{8}$"
-                  },
-                  "organisation_key" : {
-                     "type" : "string",
-                     "pattern" : "^[0-9]{8}$"
-                  },
-                  "postcode_type" : {
-                     "enum" : [
-                        "L",
-                        "S"
-                     ]
-                  }
-               },
-               "required" : [
-                  "address_key",
-                  "organisation_key",
-                  "postcode_type"
-               ]
-            },
-            "paf_udprn" : {
-               "type" : "string",
-               "pattern" : "^[0-9]{8}$"
-            }
-         },
-         "required" : [
-            "town_or_city",
-            "country_code"
-         ],
-         "anyOf" : [
+      "holiday_home_rental": {
+        "type": "boolean"
+      },
+      "restrictive_covenant": {
+        "type": "boolean"
+      },
+      "business_from_property": {
+        "type": "boolean"
+      },
+      "property_subletting": {
+        "type": "boolean"
+      },
+      "tree_preservation_order": {
+        "type": "boolean"
+      },
+      "other": {
+        "type": "boolean"
+      }
+    }
+  },
+  "rights_and_easements": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "right_of_way_public": {
+        "type": "boolean"
+      },
+      "right_of_way_private": {
+        "type": "boolean"
+      },
+      "registered_easements_hmlr": {
+        "type": "boolean"
+      },
+      "servitudes": {
+        "type": "boolean"
+      },
+      "shared_driveway": {
+        "type": "boolean"
+      },
+      "loft_access": {
+        "type": "boolean"
+      },
+      "drain_access": {
+        "type": "boolean"
+      },
+      "other": {
+        "type": "boolean"
+      }
+    }
+  }
+},
+"properties": {
+  "accessibility": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "lateral_living",
+        "step_free_access",
+        "wet_room",
+        "wheelchair_accessible",
+        "disabled_features",
+        "level_access",
+        "ramped_access",
+        "lift_access",
+        "stair_lift",
+        "wide_doorways",
+        "level_access_shower",
+        "variable_height_kitchen_surfaces"
+      ]
+    }
+  },
+  "administration_fees": {
+    "type": "string",
+    "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+  },
+  "annual_business_rates": {
+    "type": "number",
+    "minimum": 0,
+    "exclusiveMinimum": true
+  },
+  "areas": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "external": {
+        "$ref": "#/definitions/min_max_area"
+      },
+      "internal": {
+        "$ref": "#/definitions/min_max_area"
+      }
+    }
+  },
+  "available_bedrooms": {
+    "type": "integer",
+    "minimum": 1
+  },
+  "available_from_date": {
+    "$ref": "#/definitions/datetime"
+  },
+  "basement": {
+    "type": "boolean"
+  },
+  "bathrooms": {
+    "type": "integer",
+    "minimum": 0
+  },
+  "bills_included": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "electricity",
+        "gas",
+        "internet",
+        "satellite_cable_tv",
+        "telephone",
+        "tv_licence",
+        "water"
+      ]
+    }
+  },
+  "branch_reference": {
+    "type": "string",
+    "pattern": "^\\S(|(.|\\n)*\\S)\\Z",
+    "maxLength": 127
+  },
+  "broadband_supply": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "adsl",
+        "cable",
+        "fixed_wireless",
+        "fttc",
+        "fttp",
+        "mobile",
+        "none",
+        "other",
+        "satellite"
+      ]
+    }
+  },
+  "building_safety_issues": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "type": "string"
+    }
+  },
+  "burglar_alarm": {
+    "type": "boolean"
+  },
+  "business_for_sale": {
+    "type": "boolean"
+  },
+  "buyer_incentives": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "equity_loan",
+        "help_to_buy",
+        "mi_new_home",
+        "new_buy",
+        "part_buy_part_rent",
+        "shared_equity",
+        "own_new_rate_reducer",
+        "deposit_unlock",
+        "part_exchange"
+      ]
+    }
+  },
+  "category": {
+    "enum": [
+      "commercial",
+      "residential"
+    ]
+  },
+  "central_heating": {
+    "enum": [
+      "full",
+      "partial",
+      "none"
+    ]
+  },
+  "chain_free": {
+    "type": "boolean"
+  },
+  "commercial_use_classes": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "type": "string",
+      "pattern": "^(A[1-5]|B[128]|C([134]|2A?)|D[12]|sui_generis)$"
+    }
+  },
+  "connected_utilities": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "electricity",
+        "fibre_optic",
+        "gas",
+        "satellite_cable_tv",
+        "telephone",
+        "water"
+      ]
+    }
+  },
+  "conservatory": {
+    "type": "boolean"
+  },
+  "construction_year": {
+    "type": "integer"
+  },
+  "construction_materials": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "type": "string"
+    }
+  },
+  "content": {
+    "type": "array",
+    "minItems": 1,
+    "items": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "caption": {
+          "type": "string",
+          "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+        },
+        "type": {
+          "enum": [
+            "audio_tour",
+            "brochure",
+            "document",
+            "epc_graph",
+            "epc_report",
+            "floor_plan",
+            "home_pack",
+            "image",
+            "site_plan",
+            "virtual_tour"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://\\S+$"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ]
+    }
+  },
+  "decorative_condition": {
+    "enum": [
+      "excellent",
+      "good",
+      "average",
+      "needs_modernisation"
+    ]
+  },
+  "deposit": {
+    "type": "number",
+    "minimum": 0,
+    "exclusiveMinimum": true
+  },
+  "detailed_description": {
+    "type": "array",
+    "minItems": 1,
+    "items": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dimensions": {
+          "oneOf": [
             {
-               "required" : [
-                  "property_number_or_name"
-               ]
+              "$ref": "#/definitions/dimension"
             },
             {
-               "required" : [
-                  "street_name"
-               ]
+              "type": "string",
+              "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
             }
-         ]
+          ]
+        },
+        "heading": {
+          "type": "string",
+          "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+        },
+        "text": {
+          "type": "string",
+          "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+        }
       },
-      "living_rooms" : {
-         "type" : "integer",
-         "minimum" : 0
+      "hint": "In a 'detailed_description' entry, 'dimensions' requires that 'heading' is also set",
+      "dependencies": {
+        "dimensions": [
+          "heading"
+        ]
       },
-      "loft" : {
-         "type" : "boolean"
+      "anyOf": [
+        {
+          "hint": "'detailed_description' entries require at least one of 'heading' or 'text'",
+          "required": [
+            "heading"
+          ]
+        },
+        {
+          "hint": "'detailed_description' entries require at least one of 'heading' or 'text'",
+          "required": [
+            "text"
+          ]
+        }
+      ]
+    }
+  },
+  "risks": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "flooding_risks": {
+        "$ref": "#/definitions/flooding_risks"
       },
-      "new_home" : {
-         "type" : "boolean"
+      "coastal_erosion_risk": {
+        "$ref": "#/definitions/coastal_erosion"
       },
-      "open_day" : {
-         "$ref" : "#/definitions/datetime"
+      "mining_risks": {
+        "$ref": "#/definitions/mining_risks"
+      }
+    }
+  },
+  "display_address": {
+    "type": "string",
+    "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+  },
+  "double_glazing": {
+    "type": "boolean"
+  },
+  "epc_ratings": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "eer_current_rating": {
+        "$ref": "#/definitions/energy_rating"
       },
-      "outbuildings" : {
-         "type" : "boolean"
+      "eer_potential_rating": {
+        "$ref": "#/definitions/energy_rating"
       },
-      "outside_space" : {
-         "type" : "array",
-         "minItems" : 1,
-         "uniqueItems" : true,
-         "items" : {
-            "enum" : [
-               "balcony",
-               "communal_garden",
-               "private_garden",
-               "roof_terrace",
-               "terrace"
+      "eir_current_rating": {
+        "$ref": "#/definitions/energy_rating"
+      },
+      "eir_potential_rating": {
+        "$ref": "#/definitions/energy_rating"
+      }
+    }
+  },
+  "feature_list": {
+    "type": "array",
+    "minItems": 1,
+    "items": {
+      "type": "string",
+      "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+    }
+  },
+  "fireplace": {
+    "type": "boolean"
+  },
+  "fishing_rights": {
+    "type": "boolean"
+  },
+  "floor_levels": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "string",
+          "enum": [
+            "basement",
+            "ground",
+            "penthouse"
+          ]
+        }
+      ]
+    }
+  },
+  "floors": {
+    "type": "integer",
+    "minimum": 1
+  },
+  "furnished_state": {
+    "enum": [
+      "furnished",
+      "furnished_or_unfurnished",
+      "part_furnished",
+      "unfurnished"
+    ]
+  },
+  "google_street_view": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "coordinates": {
+        "$ref": "#/definitions/coordinates"
+      },
+      "heading": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 360
+      },
+      "pitch": {
+        "type": "number",
+        "minimum": -90,
+        "maximum": 90
+      }
+    },
+    "required": [
+      "coordinates",
+      "heading",
+      "pitch"
+    ]
+  },
+  "ground_rent": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "amount": {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": false
+      },
+      "review_period": {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": true
+      },
+      "date_of_next_review": {
+        "type": "string",
+        "pattern": "^([0-9]{4})(-[0-9][0-9]){0,2}$"
+      }
+    },
+    "required": [
+      "amount"
+    ]
+  },
+  "gym": {
+    "type": "boolean"
+  },
+  "heating_source": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "biomass_boiler",
+        "communal",
+        "electric_mains",
+        "electric_room_heaters",
+        "gas_mains",
+        "heat_pump_air_source",
+        "heat_pump_ground_source",
+        "lpg",
+        "night_storage_heaters",
+        "oil",
+        "other",
+        "solar_panels",
+        "solar_photovoltaic_thermal",
+        "solar_thermal",
+        "under_floor_heating",
+        "wood_burner_open_fire"
+      ]
+    }
+  },
+  "letting_arrangements": {
+    "type": "string"
+  },
+  "life_cycle_status": {
+    "enum": [
+      "available",
+      "under_offer",
+      "sold_subject_to_contract",
+      "sold",
+      "let_agreed",
+      "let"
+    ]
+  },
+  "listed_building_grade": {
+    "enum": [
+      "category_a",
+      "category_b",
+      "category_c",
+      "grade_a",
+      "grade_b",
+      "grade_b_plus",
+      "grade_one",
+      "grade_two",
+      "grade_two_star",
+      "locally_listed"
+    ]
+  },
+  "listing_reference": {
+    "type": "string",
+    "pattern": "^\\S(|(.|\\n)*\\S)\\Z",
+    "maxLength": 127
+  },
+  "local_authority": {
+    "type": "object",
+    "additionalProperties": false,
+    "maxProperties": 1,
+    "minProperties": 1,
+    "properties": {
+      "council_tax_band": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I"
             ]
-         }
-      },
-      "parking" : {
-         "type" : "array",
-         "minItems" : 1,
-         "uniqueItems" : true,
-         "items" : {
-            "enum" : [
-               "double_garage",
-               "off_street_parking",
-               "residents_parking",
-               "single_garage",
-               "underground"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "exempt": {
+                "type": "string",
+                "minLength": 1
+              },
+              "not_yet_known": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "oneOf": [
+              {
+                "required": ["exempt"]
+              },
+              {
+                "required": ["not_yet_known"]
+              }
             ]
-         }
+          }
+        ]
       },
-      "pets_allowed" : {
-         "type" : "boolean"
+      "domestic_rates": {
+        "oneOf": [
+          {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "exempt": {
+                "type": "string",
+                "minLength": 1
+              },
+              "not_yet_known": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "oneOf": [
+              {
+                "required": ["exempt"]
+              },
+              {
+                "required": ["not_yet_known"]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "location": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "property_number_or_name": {
+        "type": [
+          "integer",
+          "string"
+        ],
+        "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
       },
-      "porter_security" : {
-         "type" : "boolean"
+      "street_name": {
+        "type": "string",
+        "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
       },
-      "pricing" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "properties" : {
-            "auction" : {
-               "type" : "boolean"
+      "locality": {
+        "type": "string",
+        "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+      },
+      "town_or_city": {
+        "type": "string",
+        "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+      },
+      "county": {
+        "type": "string",
+        "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+      },
+      "postal_code": {
+        "type": "string",
+        "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+      },
+      "country_code": {
+        "type": "string",
+        "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
+      },
+      "coordinates": {
+        "$ref": "#/definitions/coordinates"
+      },
+      "paf_address": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "address_key": {
+            "type": "string",
+            "pattern": "^[0-9]{8}$"
+          },
+          "organisation_key": {
+            "type": "string",
+            "pattern": "^[0-9]{8}$"
+          },
+          "postcode_type": {
+            "enum": [
+              "L",
+              "S"
+            ]
+          }
+        },
+        "required": [
+          "address_key",
+          "organisation_key",
+          "postcode_type"
+        ]
+      },
+      "paf_udprn": {
+        "type": "string",
+        "pattern": "^[0-9]{8}$"
+      },
+      "uprn": {
+        "type": "string",
+        "pattern": "^[0-9]{1,12}$"
+      }
+    },
+    "required": [
+      "town_or_city",
+      "country_code"
+    ],
+    "anyOf": [
+      {
+        "required": [
+          "property_number_or_name"
+        ]
+      },
+      {
+        "required": [
+          "street_name"
+        ]
+      }
+    ]
+  },
+  "living_rooms": {
+    "type": "integer",
+    "minimum": 0
+  },
+  "loft": {
+    "type": "boolean"
+  },
+  "new_home": {
+    "type": "boolean"
+  },
+  "restrictions": {
+    "$ref": "#/definitions/restrictions"
+  },
+  "rights_and_easements": {
+    "$ref": "#/definitions/rights_and_easements"
+  },
+  "open_day": {
+    "$ref": "#/definitions/datetime"
+  },
+  "outbuildings": {
+    "type": "boolean"
+  },
+  "outside_space": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "balcony",
+        "communal_garden",
+        "private_garden",
+        "roof_terrace",
+        "terrace"
+      ]
+    }
+  },
+  "parking": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "double_garage",
+        "off_street_parking",
+        "residents_parking",
+        "single_garage",
+        "underground",
+        "communal_car_park_allocated_space",
+        "communal_car_park_no_allocated_space",
+        "disabled_parking_available",
+        "disabled_parking_not_available",
+        "driveway_private",
+        "driveway_shared",
+        "ev_charging_private",
+        "ev_charging_shared",
+        "garage",
+        "garage_bloc",
+        "garage_carport",
+        "garage_detached",
+        "garage_integral",
+        "gated_parking",
+        "no_parking_available",
+        "rear_of_property",
+        "street_parking_permit_not_required",
+        "street_parking_permit_required",
+        "undercroft",
+        "underground_parking_allocated_space",
+        "underground_parking_no_allocated_space",
+        "other"
+      ]
+    }
+  },
+  "pets_allowed": {
+    "type": "boolean"
+  },
+  "known_planning_considerations" : {
+    "type": "string",
+    "minLength": 1
+  },
+  "porter_security": {
+    "type": "boolean"
+  },
+  "pricing": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "auction": {
+        "type": "boolean"
+      },
+      "currency_code": {
+        "type": "string",
+        "pattern": "^[A-Z]{3}$"
+      },
+      "price": {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": true
+      },
+      "price_per_unit_area": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "units": {
+            "$ref": "#/definitions/area_units"
+          },
+          "price": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          }
+        },
+        "required": [
+          "units",
+          "price"
+        ]
+      },
+      "price_qualifier": {
+        "enum": [
+          "coming_soon",
+          "fixed_price",
+          "from",
+          "guide_price",
+          "non_quoting",
+          "offers_in_the_region_of",
+          "offers_over",
+          "sale_by_tender"
+        ]
+      },
+      "rent_frequency": {
+        "$ref": "#/definitions/frequencies"
+      },
+      "transaction_type": {
+        "enum": [
+          "rent",
+          "sale"
+        ]
+      }
+    },
+    "required": [
+      "currency_code",
+      "transaction_type"
+    ]
+  },
+  "property_type": {
+    "anyOf": [
+      {
+        "type": "string",
+        "enum": [
+          "barn_conversion",
+          "block_of_flats",
+          "bungalow",
+          "business_park",
+          "chalet",
+          "chateau",
+          "cottage",
+          "country_house",
+          "detached",
+          "detached_bungalow",
+          "end_terrace",
+          "equestrian",
+          "farm",
+          "farmhouse",
+          "finca",
+          "flat",
+          "hotel",
+          "houseboat",
+          "industrial",
+          "land",
+          "leisure",
+          "light_industrial",
+          "link_detached",
+          "lodge",
+          "longere",
+          "maisonette",
+          "mews",
+          "office",
+          "park_home",
+          "parking",
+          "pub_bar",
+          "restaurant",
+          "retail",
+          "riad",
+          "semi_detached",
+          "semi_detached_bungalow",
+          "studio",
+          "terraced",
+          "terraced_bungalow",
+          "town_house",
+          "villa",
+          "warehouse"
+        ]
+      },
+      {
+        "type": "string",
+        "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+      }
+    ]
+  },
+  "rateable_value": {
+    "type": "number",
+    "minimum": 0,
+    "exclusiveMinimum": true
+  },
+  "rental_term": {
+    "oneOf": [
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "minimum_length": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "units": {
+            "enum": [
+              "days",
+              "weeks",
+              "months",
+              "years"
+            ]
+          }
+        },
+        "required": [
+          "minimum_length",
+          "units"
+        ]
+      },
+      {
+        "type": "string",
+        "enum": [
+          "fixed_term",
+          "long_term",
+          "short_term"
+        ]
+      }
+    ]
+  },
+  "repossession": {
+    "type": "boolean"
+  },
+  "retirement": {
+    "type": "boolean"
+  },
+  "sap_rating": {
+    "$ref": "#/definitions/energy_rating"
+  },
+  "service_charge": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "charge": {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": true
+      },
+      "per_unit_area_units": {
+        "$ref": "#/definitions/area_units"
+      },
+      "frequency": {
+        "$ref": "#/definitions/frequencies"
+      }
+    },
+    "required": [
+      "charge"
+    ]
+  },
+  "serviced": {
+    "type": "boolean"
+  },
+  "sewerage_supply": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "mains",
+        "septic_tank",
+        "domestic_small_sewage_treatment_plants",
+        "cesspit",
+        "cesspool",
+        "other"
+      ]
+    }
+  },
+  "electricity_supply": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "mains_supply",
+        "private_supply",
+        "solar_pv_panels",
+        "wind_turbine",
+        "generator",
+        "other"
+      ]
+    }
+  },
+  "shared_accommodation": {
+    "type": "boolean"
+  },
+  "summary_description": {
+    "type": "string",
+    "pattern": "^\\S(|(.|\\n)*\\S)\\Z"
+  },
+  "swimming_pool": {
+    "type": "boolean"
+  },
+  "tenanted": {
+    "type": "boolean"
+  },
+  "tenant_eligibility": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "properties": {
+      "dss": {
+        "enum": [
+          "accepted",
+          "excluded",
+          "only"
+        ]
+      },
+      "students": {
+        "enum": [
+          "accepted",
+          "excluded",
+          "only"
+        ]
+      }
+    }
+  },
+  "tennis_court": {
+    "type": "boolean"
+  },
+  "tenure": {
+    "oneOf": [
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "pattern": "commonhold"
+          },
+          "details": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "pattern": "feudal"
+          }
+        }
+      },
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "pattern": "^non_traditional$"
+          }
+        }
+      },
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "pattern": "^freehold$"
+          }
+        }
+      },
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 2,
+        "properties": {
+          "type": {
+            "type": "string",
+            "pattern": "leasehold"
+          },
+          "expiry_date": {
+            "type": "string",
+            "pattern": "^([0-9]{4})(-[0-9][0-9]){0,2}$"
+          },
+          "years_remaining": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": false
+          },
+          "shared_ownership": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "percentage": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 99
+              },
+              "rent": {
+                "type": "number",
+                "minimum": 0,
+                "exclusiveMinimum": true
+              },
+              "rent_frequency": {
+                "enum": [
+                  "per_day",
+                  "per_week",
+                  "per_month",
+                  "per_quarter",
+                  "per_year"
+                ]
+              },
+              "details": {
+                "type": "string"
+              }
             },
-            "currency_code" : {
-               "type" : "string",
-               "pattern" : "^[A-Z]{3}$"
-            },
-            "price" : {
-               "type" : "number",
-               "minimum" : 0,
-               "exclusiveMinimum" : true
-            },
-            "price_per_unit_area" : {
-               "type" : "object",
-               "additionalProperties" : false,
-               "properties" : {
-                  "units" : {
-                     "$ref" : "#/definitions/area_units"
-                  },
-                  "price" : {
-                     "type" : "number",
-                     "minimum" : 0,
-                     "exclusiveMinimum" : true
-                  }
-               },
-               "required" : [
-                  "units",
+            "oneOf": [
+              {
+                "maxProperties": 0
+              },
+              {
+                "maxProperties": 1,
+                "required": ["percentage"]
+              },
+              {
+                "minProperties": 2,
+                "required": ["rent", "rent_frequency"]
+              }
+            ]
+          }
+        },
+        "oneOf": [
+          {
+            "required": ["type", "expiry_date"],
+            "not": {"required": ["years_remaining"]}
+          },
+          {
+            "required": ["type", "years_remaining"],
+            "not": {"required": ["expiry_date"]}
+          }
+        ]
+      },
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "pattern": "^share_of_freehold$"
+          },
+          "expiry_date": {
+            "type": "string",
+            "pattern": "^([0-9]{4})(-[0-9][0-9]){0,2}$"
+          },
+          "years_remaining": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": false
+          }
+        },
+        "anyOf": [
+          {
+            "required": ["type"],
+            "not": {"required": ["years_remaining", "expiry_date"]}
+          },
+          {
+            "required": ["type", "expiry_date"],
+            "not": {"required": ["years_remaining"]}
+          },
+          {
+            "required": ["type", "years_remaining"],
+            "not": {"required": ["expiry_date"]}
+          }
+        ]
+      }
+    ]
+  },
+  "total_bedrooms": {
+    "type": "integer",
+    "minimum": 0
+  },
+  "utility_room": {
+    "type": "boolean"
+  },
+  "waterfront": {
+    "type": "boolean"
+  },
+  "water_supply": {
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "enum": [
+        "mains",
+        "private_well",
+        "private_spring",
+        "private_borehole",
+        "public_well",
+        "public_spring",
+        "public_borehole",
+        "other"
+      ]
+    }
+  },
+  "wood_floors": {
+    "type": "boolean"
+  }
+},
+"hint": "All mandatory fields must be present",
+"required": [
+  "branch_reference",
+  "category",
+  "detailed_description",
+  "life_cycle_status",
+  "listing_reference",
+  "location",
+  "pricing",
+  "property_type"
+],
+"allOf": [
+  {
+    "$ref": "#/constraints/pricing"
+  },
+  {
+    "$ref": "#/constraints/price_per_unit_area"
+  },
+  {
+    "hint": "Determine if this is a commercial or residential listing",
+    "oneOf": [
+      {
+        "$ref": "#/constraints/residential"
+      },
+      {
+        "$ref": "#/constraints/commercial"
+      }
+    ]
+  },
+  {
+    "hint": "Determine if this is a sale or rental listing",
+    "oneOf": [
+      {
+        "$ref": "#/constraints/sale"
+      },
+      {
+        "$ref": "#/constraints/rent"
+      }
+    ]
+  },
+  {
+    "hint": "Determine if this is a GB or overseas listing",
+    "oneOf": [
+      {
+        "$ref": "#/constraints/gb"
+      },
+      {
+        "$ref": "#/constraints/overseas"
+      }
+    ]
+  }
+],
+"constraints": {
+  "residential": {
+    "properties": {
+      "category": {
+        "enum": [
+          "residential"
+        ]
+      }
+    },
+    "anyOf": [
+      {
+        "properties": {
+          "shared_accommodation": {
+            "enum": [
+              true
+            ]
+          }
+        },
+        "required": [
+          "available_bedrooms",
+          "shared_accommodation"
+        ]
+      },
+      {
+        "required": [
+          "shared_accommodation"
+        ],
+        "not": {
+          "required": [
+            "available_bedrooms"
+          ]
+        }
+      },
+      {
+        "allOf": [
+          {
+            "not": {
+              "required": [
+                "available_bedrooms"
+              ]
+            }
+          },
+          {
+            "not": {
+              "required": [
+                "shared_accommodation"
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "oneOf": [
+      {
+        "properties": {
+          "total_bedrooms": {
+            "maximum": 1
+          },
+          "property_type": {
+            "enum": [
+              "studio"
+            ]
+          }
+        },
+        "required": [
+          "total_bedrooms"
+        ]
+      },
+      {
+        "properties": {
+          "property_type": {
+            "enum": [
+              "studio"
+            ]
+          }
+        },
+        "not": {
+          "required": [
+            "total_bedrooms"
+          ]
+        }
+      },
+      {
+        "not": {
+          "properties": {
+            "property_type": {
+              "enum": [
+                "studio"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "commercial": {
+    "properties": {
+      "category": {
+        "enum": [
+          "commercial"
+        ]
+      }
+    }
+  },
+  "pricing": {
+    "oneOf": [
+      {
+        "properties": {
+          "pricing": {
+            "anyOf": [
+              {
+                "required": [
                   "price"
-               ]
-            },
-            "price_qualifier" : {
-               "enum" : [
-                  "fixed_price",
-                  "from",
-                  "guide_price",
-                  "non_quoting",
-                  "offers_in_the_region_of",
-                  "offers_over",
-                  "price_on_application",
-                  "sale_by_tender"
-               ]
-            },
-            "rent_frequency" : {
-               "$ref" : "#/definitions/frequencies"
-            },
-            "transaction_type" : {
-               "enum" : [
-                  "rent",
-                  "sale"
-               ]
-            }
-         },
-         "required" : [
-            "currency_code",
-            "transaction_type"
-         ]
-      },
-      "property_type" : {
-         "anyOf" : [
-            {
-               "type" : "string",
-               "enum" : [
-                  "barn_conversion",
-                  "block_of_flats",
-                  "bungalow",
-                  "business_park",
-                  "chalet",
-                  "chateau",
-                  "cottage",
-                  "country_house",
-                  "detached",
-                  "detached_bungalow",
-                  "end_terrace",
-                  "equestrian",
-                  "farm",
-                  "farmhouse",
-                  "finca",
-                  "flat",
-                  "hotel",
-                  "houseboat",
-                  "industrial",
-                  "land",
-                  "leisure",
-                  "light_industrial",
-                  "link_detached",
-                  "lodge",
-                  "longere",
-                  "maisonette",
-                  "mews",
-                  "office",
-                  "park_home",
-                  "parking",
-                  "pub_bar",
-                  "restaurant",
-                  "retail",
-                  "riad",
-                  "semi_detached",
-                  "semi_detached_bungalow",
-                  "studio",
-                  "terraced",
-                  "terraced_bungalow",
-                  "town_house",
-                  "villa",
-                  "warehouse"
-               ]
-            },
-            {
-               "type" : "string",
-               "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-            }
-         ]
-      },
-      "rateable_value" : {
-         "type" : "number",
-         "minimum" : 0,
-         "exclusiveMinimum" : true
-      },
-      "rental_term" : {
-         "oneOf" : [
-            {
-               "type" : "object",
-               "additionalProperties" : false,
-               "properties" : {
-                  "minimum_length" : {
-                     "type" : "number",
-                     "minimum" : 0,
-                     "exclusiveMinimum" : true
-                  },
-                  "units" : {
-                     "enum" : [
-                        "days",
-                        "weeks",
-                        "months",
-                        "years"
-                     ]
-                  }
-               },
-               "required" : [
-                  "minimum_length",
-                  "units"
-               ]
-            },
-            {
-               "type" : "string",
-               "enum" : [
-                  "fixed_term",
-                  "long_term",
-                  "short_term"
-               ]
-            }
-         ]
-      },
-      "repossession" : {
-         "type" : "boolean"
-      },
-      "retirement" : {
-         "type" : "boolean"
-      },
-      "sap_rating" : {
-         "$ref" : "#/definitions/energy_rating"
-      },
-      "service_charge" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "minProperties" : 1,
-         "properties" : {
-            "charge" : {
-               "type" : "number",
-               "minimum" : 0,
-               "exclusiveMinimum" : true
-            },
-            "per_unit_area_units" : {
-               "$ref" : "#/definitions/area_units"
-            },
-            "frequency" : {
-               "$ref" : "#/definitions/frequencies"
-            }
-         },
-         "required" : [
-            "charge"
-         ],
-         "oneOf" : [
-            {
-               "required" : [
-                  "per_unit_area_units"
-               ]
-            },
-            {
-               "required" : [
-                  "frequency"
-               ]
-            }
-         ]
-      },
-      "serviced" : {
-         "type" : "boolean"
-      },
-      "shared_accommodation" : {
-         "type" : "boolean"
-      },
-      "summary_description" : {
-         "type" : "string",
-         "pattern" : "^\\S(|(.|\\n)*\\S)\\Z"
-      },
-      "swimming_pool" : {
-         "type" : "boolean"
-      },
-      "tenanted" : {
-         "type" : "boolean"
-      },
-      "tenant_eligibility" : {
-         "type" : "object",
-         "additionalProperties" : false,
-         "minProperties" : 1,
-         "properties" : {
-            "dss" : {
-               "enum" : [
-                  "accepted",
-                  "excluded",
-                  "only"
-               ]
-            },
-            "students" : {
-               "enum" : [
-                  "accepted",
-                  "excluded",
-                  "only"
-               ]
-            }
-         }
-      },
-      "tennis_court" : {
-         "type" : "boolean"
-      },
-      "tenure" : {
-         "enum" : [
-            "feudal",
-            "freehold",
-            "leasehold",
-            "share_of_freehold"
-         ]
-      },
-      "total_bedrooms" : {
-         "type" : "integer",
-         "minimum" : 0
-      },
-      "utility_room" : {
-         "type" : "boolean"
-      },
-      "waterfront" : {
-         "type" :"boolean"
-      },
-      "wood_floors" : {
-         "type" : "boolean"
-      }
-   },
-   "hint" : "All mandatory fields must be present",
-   "required" : [
-      "branch_reference",
-      "category",
-      "detailed_description",
-      "life_cycle_status",
-      "listing_reference",
-      "location",
-      "pricing",
-      "property_type"
-   ],
-   "allOf" : [
-      { "$ref" : "#/constraints/pricing" },
-      { "$ref" : "#/constraints/price_per_unit_area" },
-      {
-         "hint": "Determine if this is a commercial or residential listing",
-         "oneOf" : [
-            { "$ref" : "#/constraints/residential" },
-            { "$ref" : "#/constraints/commercial" }
-         ]
-      },
-      {
-         "hint": "Determine if this is a sale or rental listing",
-         "oneOf" : [
-            { "$ref" : "#/constraints/sale" },
-            { "$ref" : "#/constraints/rent" }
-         ]
-      },
-      {
-         "hint": "Determine if this is a GB or overseas listing",
-         "oneOf" : [
-            { "$ref" : "#/constraints/gb" },
-            { "$ref" : "#/constraints/overseas" }
-         ]
-      }
-   ],
-   "constraints" : {
-      "residential": {
-         "properties" : {
-            "category" : {
-               "enum" : [
-                  "residential"
-               ]
-            }
-         },
-         "anyOf" : [
-            {
-               "properties" : {
-                  "shared_accommodation" : {
-                     "enum" : [
-                        true
-                     ]
-                  }
-               },
-               "required" : [
-                  "available_bedrooms",
-                  "shared_accommodation"
-               ]
-            },
-            {
-               "required" : [
-                  "shared_accommodation"
-               ],
-               "not" : {
-                  "required" : [
-                     "available_bedrooms"
+                ]
+              },
+              {
+                "required": [
+                  "price_per_unit_area"
+                ]
+              }
+            ],
+            "properties": {
+              "price_qualifier": {
+                "not": {
+                  "enum": [
+                    "non_quoting"
                   ]
-               }
-            },
-            {
-               "allOf" : [
-                  {
-                     "not" : {
-                        "required" : [
-                           "available_bedrooms"
-                        ]
-                     }
-                  },
-                  {
-                     "not" : {
-                        "required" : [
-                           "shared_accommodation"
-                        ]
-                     }
-                  }
-               ]
+                }
+              }
             }
-         ],
-         "oneOf" : [
-            {
-               "properties" : {
-                  "total_bedrooms" : {
-                     "maximum" : 1
-                  },
-                  "property_type" : {
-                     "enum" : [
-                        "studio"
-                     ]
-                  }
-               },
-               "required" : [
-                  "total_bedrooms"
-               ]
-            },
-            {
-               "properties" : {
-                  "property_type" : {
-                     "enum" : [
-                        "studio"
-                     ]
-                  }
-               },
-               "not" : {
-                  "required" : [
-                     "total_bedrooms"
+          }
+        }
+      },
+      {
+        "properties": {
+          "category": {
+            "enum": [
+              "commercial"
+            ]
+          },
+          "location": {
+            "properties": {
+              "country_code": {
+                "pattern": "^GB"
+              }
+            }
+          },
+          "pricing": {
+            "allOf": [
+              {
+                "not": {
+                  "required": [
+                    "price"
                   ]
-               }
-            },
-            {
-               "not" : {
-                  "properties" : {
-                     "property_type" : {
-                        "enum" : ["studio"]
-                     }
-                  }
-               }
+                }
+              },
+              {
+                "not": {
+                  "required": [
+                    "price_per_unit_area"
+                  ]
+                }
+              }
+            ],
+            "required": [
+              "price_qualifier"
+            ],
+            "properties": {
+              "price_qualifier": {
+                "enum": [
+                  "non_quoting"
+                ]
+              }
             }
-         ]
-      },
-      "commercial" : {
-         "properties" : {
-            "category" : {
-               "enum" : [
-                  "commercial"
-               ]
-            }
-         }
-      },
-      "pricing" : {
-         "oneOf" : [
-            {
-               "properties" : {
-                  "pricing" : {
-                     "anyOf" : [
-                        {
-                           "required" : [
-                              "price"
-                           ]
-                        },
-                        {
-                           "required" : [
-                              "price_per_unit_area"
-                           ]
-                        }
-                     ],
-                     "properties" : {
-                        "price_qualifier" : {
-                           "not" : {
-                              "enum" : [
-                                 "non_quoting"
-                              ]
-                           }
-                        }
-                     }
-                  }
-               }
-            },
-            {
-               "properties" : {
-                  "category" : {
-                     "enum" : [
-                        "commercial"
-                     ]
-                  },
-                  "location" : {
-                     "properties" : {
-                        "country_code" : {
-                           "pattern" : "^GB"
-                        }
-                     }
-                  },
-                  "pricing" : {
-                     "allOf" : [
-                        {
-                           "not" : {
-                              "required" : [
-                                 "price"
-                              ]
-                           }
-                        },
-                        {
-                           "not" : {
-                              "required" : [
-                                 "price_per_unit_area"
-                              ]
-                           }
-                        }
-                     ],
-                     "required" : [
-                        "price_qualifier"
-                     ],
-                     "properties" : {
-                        "price_qualifier" : {
-                           "enum" : [
-                              "non_quoting"
-                           ]
-                        }
-                     }
-                  }
-               }
-            }
-         ]
-      },
-      "price_per_unit_area" : {
-         "oneOf" : [
-            {
-               "properties" : {
-                  "pricing" : {
-                     "required" : [
-                        "price_per_unit_area"
-                     ]
-                  },
-                  "areas" : {
-                     "required" : [
-                        "internal"
-                     ]
-                  }
-               },
-               "required" : [
-                  "areas"
-               ]
-            },
-            {
-               "properties" : {
-                  "pricing" : {
-                     "not" : {
-                        "required" : [
-                           "price_per_unit_area"
-                        ]
-                     }
-                  }
-               }
-            }
-         ]
-      },
-      "sale" : {
-         "properties" : {
-            "life_cycle_status" : {
-               "hint" : "For a sale listing, life_cycle_status was invalid",
-               "enum" : [
-                  "available",
-                  "under_offer",
-                  "sold_subject_to_contract",
-                  "sold"
-               ]
-            },
-            "pricing" : {
-               "properties" : {
-                  "transaction_type" : {
-                     "hint" : "For a sale listing, 'transaction_type' must be 'sale'",
-                     "enum" : [
-                        "sale"
-                     ]
-                  }
-               }
-            }
-         }
-      },
-      "rent" : {
-         "properties" : {
-            "pricing" : {
-               "hint" : "For rental listings, 'rent_frequency' must be supplied",
-               "properties" : {
-                  "transaction_type" : {
-                     "hint" : "For rental listings, 'transaction_type' must be 'rent'",
-                     "enum" : [
-                        "rent"
-                     ]
-                  }
-               },
-               "required" : [
-                  "rent_frequency"
-               ]
-            },
-            "life_cycle_status" : {
-               "enum" : [
-                  "available",
-                  "under_offer",
-                  "let_agreed",
-                  "let"
-               ]
-            }
-         }
-      },
-      "gb" : {
-         "properties" : {
-            "location" : {
-               "properties" : {
-                  "country_code" : {
-                     "hint" : "For GB listings, 'country_code' must start with 'GB'",
-                     "pattern" : "^GB"
-                  },
-                  "postal_code" : {
-                     "pattern" : "^[A-PR-UWYZ][A-HJ-Y]?[0-9][0-9A-HJKMNPR-Y]? [0-9][ABD-HJLNP-UW-Z]{2}$"
-                  }
-               },
-               "hint" : "For GB listings, 'postal_code' is required",
-               "required" : [
-                  "postal_code"
-               ]
-            }
-         }
-      },
-      "overseas" : {
-         "properties" : {
-            "location" : {
-               "properties" : {
-                  "country_code" : {
-                     "not" : {
-                        "pattern" : "^GB"
-                     }
-                  }
-               }
-            }
-         }
+          }
+        }
       }
-   }
+    ]
+  },
+  "price_per_unit_area": {
+    "oneOf": [
+      {
+        "properties": {
+          "pricing": {
+            "required": [
+              "price_per_unit_area"
+            ]
+          },
+          "areas": {
+            "required": [
+              "internal"
+            ]
+          }
+        },
+        "required": [
+          "areas"
+        ]
+      },
+      {
+        "properties": {
+          "pricing": {
+            "not": {
+              "required": [
+                "price_per_unit_area"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "sale": {
+    "properties": {
+      "life_cycle_status": {
+        "hint": "For a sale listing, life_cycle_status was invalid",
+        "enum": [
+          "available",
+          "under_offer",
+          "sold_subject_to_contract",
+          "sold"
+        ]
+      },
+      "pricing": {
+        "properties": {
+          "transaction_type": {
+            "hint": "For a sale listing, 'transaction_type' must be 'sale'",
+            "enum": [
+              "sale"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "rent": {
+    "properties": {
+      "pricing": {
+        "hint": "For rental listings, 'rent_frequency' must be supplied",
+        "properties": {
+          "transaction_type": {
+            "hint": "For rental listings, 'transaction_type' must be 'rent'",
+            "enum": [
+              "rent"
+            ]
+          }
+        },
+        "required": [
+          "rent_frequency"
+        ]
+      },
+      "life_cycle_status": {
+        "enum": [
+          "available",
+          "under_offer",
+          "let_agreed",
+          "let"
+        ]
+      }
+    }
+  },
+  "gb": {
+    "properties": {
+      "location": {
+        "properties": {
+          "country_code": {
+            "hint": "For GB listings, 'country_code' must start with 'GB'",
+            "pattern": "^GB"
+          },
+          "postal_code": {
+            "pattern": "^[A-PR-UWYZ][A-HJ-Y]?[0-9][0-9A-HJKMNPR-Y]? [0-9][ABD-HJLNP-UW-Z]{2}$"
+          }
+        },
+        "hint": "For GB listings, 'postal_code' is required",
+        "required": [
+          "postal_code"
+        ]
+      }
+    }
+  },
+  "overseas": {
+    "properties": {
+      "location": {
+        "properties": {
+          "country_code": {
+            "not": {
+              "pattern": "^GB"
+            }
+          }
+        }
+      }
+    }
+  }
 }
+  }
+  

--- a/src/Groups/GroundRent.php
+++ b/src/Groups/GroundRent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace mehmetbulut\Zoopla\Groups;
+
+use mehmetbulut\Zoopla\SynthesizeTrait;
+
+class GroundRent implements \JsonSerializable
+{
+	use SynthesizeTrait;
+
+	protected $arrSynthesize = array(
+		'amount' => array('type' => 'number', 'required' => true),
+		'review_period' => array('type' => 'number', 'required' => false),
+		'date_of_next_review' => array('type' => 'date', 'required' => false)
+	);
+
+	public function __construct(float $amount, int $review_period = null, string $date_of_next_review = null)
+	{
+		$this->amount = $amount;
+
+		if (!empty($review_period)) {
+			$this->review_period = $review_period;
+		}
+
+		if (!empty($date_of_next_review)) {
+			$this->date_of_next_review = $date_of_next_review;
+		}
+	}
+}

--- a/src/Request/BranchPropertyList.php
+++ b/src/Request/BranchPropertyList.php
@@ -6,7 +6,7 @@ class BranchPropertyList extends RequestBase {
 
 	protected $path = '/listing/list';
 
-	protected $schema = 'http://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/listing/list.json';
+	protected $schema = 'http://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/list.json';
 
 	protected $schemaJsonFileName = 'branch-property-listing.json';
 

--- a/src/Request/BranchUpdate.php
+++ b/src/Request/BranchUpdate.php
@@ -8,7 +8,7 @@ class BranchUpdate extends RequestBase
 {
 	protected $path = '/branch/update';
 
-	protected $schema = 'https://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/branch/update.json';
+	protected $schema = 'https://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/branch/update.json';
 
 	protected $schemaJsonFileName = 'branch-update.json';
 

--- a/src/Request/RemoveProperty.php
+++ b/src/Request/RemoveProperty.php
@@ -8,7 +8,7 @@ class RemoveProperty extends RequestBase {
 
 	protected $path = '/listing/delete';
 
-	protected $schema = 'https://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/listing/delete.json';
+	protected $schema = 'https://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/delete.json';
 
 	protected $schemaJsonFileName = 'remove-property.json';
 

--- a/src/Request/RequestBase.php
+++ b/src/Request/RequestBase.php
@@ -13,8 +13,8 @@ class RequestBase implements \JsonSerializable
 {
 	use SynthesizeTrait;
 
-	private $liveUrl = 'https://realtime-listings-api.webservices.zpg.co.uk/live/v1';
-	private $testUrl = 'https://realtime-listings-api.webservices.zpg.co.uk/sandbox/v1';
+	private $liveUrl = 'https://realtime-listings-api.webservices.zpg.co.uk/live/v2';
+	private $testUrl = 'https://realtime-listings-api.webservices.zpg.co.uk/sandbox/v2';
 
 	/*protected function removeEmptyValues($property)
 	{

--- a/src/Request/SendProperty.php
+++ b/src/Request/SendProperty.php
@@ -6,6 +6,7 @@ use mehmetbulut\Zoopla\Groups\Areas;
 use mehmetbulut\Zoopla\Groups\Content;
 use mehmetbulut\Zoopla\Groups\EpcRating;
 use mehmetbulut\Zoopla\Groups\GoogleStreetView;
+use mehmetbulut\Zoopla\Groups\GroundRent;
 use mehmetbulut\Zoopla\Groups\LeaseExpiry;
 use mehmetbulut\Zoopla\Groups\Location;
 use mehmetbulut\Zoopla\Groups\MinimumContractLength;
@@ -77,7 +78,7 @@ class SendProperty extends RequestBase
 
 		'annual_business_rates' => array('type' => 'number', ),
 		'deposit' => array('type' => 'number', ),
-		'ground_rent' => array('type' => 'number', ),
+		'ground_rent' => array('type' => 'object', 'class' => GroundRent::class),
 
 		'available_from_date' => array('type' => 'date', ),
 		'open_day' => array('type' => 'date', ),

--- a/src/Request/SendProperty.php
+++ b/src/Request/SendProperty.php
@@ -12,6 +12,7 @@ use mehmetbulut\Zoopla\Groups\MinimumContractLength;
 use mehmetbulut\Zoopla\Groups\Pricing;
 use mehmetbulut\Zoopla\Groups\ServiceCharge;
 use mehmetbulut\Zoopla\Groups\TenantEligibility;
+use mehmetbulut\Zoopla\Values\Accessibility;
 use mehmetbulut\Zoopla\Values\BillsIncluded;
 use mehmetbulut\Zoopla\Values\BuyerIncentives;
 use mehmetbulut\Zoopla\Values\Category;
@@ -97,7 +98,7 @@ class SendProperty extends RequestBase
 		'feature_list' => array('type' => 'array', ),
 
 		'fishing_rights' => array('type' => 'boolean', ),
-		'accessibility' => array('type' => 'boolean', ),
+		'accessibility' => array('type' => 'array', 'class' => Accessibility::class, ),
 		'shared_accommodation' => array('type' => 'boolean', ),
 		'basement' => array('type' => 'boolean', ),
 		'burglar_alarm' => array('type' => 'boolean', ),

--- a/src/Request/SendProperty.php
+++ b/src/Request/SendProperty.php
@@ -52,7 +52,6 @@ class SendProperty extends RequestBase
 		'service_charge' => array('type' => 'object', 'class' => ServiceCharge::class, ),
 		'epc_ratings' => array('type' => 'object', 'class' => EpcRating::class, ),
 		'google_street_view' => array('type' => 'object', 'class' => GoogleStreetView::class, ),
-		'lease_expiry' => array('type' => 'object', 'class' => LeaseExpiry::class, ),
 
 		'available_bedrooms' => array('type' => 'integer', ),
 		'bathrooms' => array('type' => 'integer', ),
@@ -64,7 +63,7 @@ class SendProperty extends RequestBase
 
 		'property_type' => array('type' => 'string', ),
 		'listed_building_grade' => array('type' => 'enum', 'class' => ListedBuildingGrade::class, ),
-		'tenure' => array('type' => 'enum', 'class' => Tenure::class, ),
+		'tenure' => array('type' => 'object', 'class' => Tenure::class, ),
 		'central_heating' => array('type' => 'enum', 'class' => CentralHeating::class, ),
 		'decorative_condition' => array('type' => 'enum', 'class' => DecorativeCondition::class, ),
 		'category' => array('type' => 'enum', 'class' => Category::class, ),

--- a/src/Request/SendProperty.php
+++ b/src/Request/SendProperty.php
@@ -32,7 +32,7 @@ class SendProperty extends RequestBase
 {
 	protected $path = '/listing/update';
 
-	protected $schema = 'https://realtime-listings.webservices.zpg.co.uk/docs/v1.2/schemas/listing/update.json';
+	protected $schema = 'https://realtime-listings.webservices.zpg.co.uk/docs/v2.3/schemas/listing/update.json';
 
 	protected $schemaJsonFileName = 'send-property.json';
 

--- a/src/Values/Accessibility.php
+++ b/src/Values/Accessibility.php
@@ -8,4 +8,14 @@ class Accessibility extends ValuesBase
 	const StepFreeAccess = 'step_free_access';
 	const WheelchairAccessible = 'wheelchair_accessible';
 	const WetRoom = 'wet_room';
+	const DisabledFeatures = 'disabled_features';
+	const LevelAccess = 'level_access';
+	const RampedAccess = 'ramped_access';
+	const LiftAccess = 'lift_access';
+	const StairLift = 'stair_lift';
+	const WideDorrways = 'wide_doorways';
+	const LevelAccessShower = 'level_access_shower';
+	const VariableHeightKitchenSurfaces = 'variable_height_kitchen_surfaces';
+
+
 }

--- a/src/Values/Accessibility.php
+++ b/src/Values/Accessibility.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace mehmetbulut\Zoopla\Values;
+
+class Accessibility extends ValuesBase
+{
+	const LateralLiving = 'lateral_living';
+	const StepFreeAccess = 'step_free_access';
+	const WheelchairAccessible = 'wheelchair_accessible';
+	const WetRoom = 'wet_room';
+}

--- a/src/Values/Tenure.php
+++ b/src/Values/Tenure.php
@@ -4,6 +4,7 @@ namespace mehmetbulut\Zoopla\Values;
 
 class Tenure extends ValuesBase
 {
+	// TODO: oneOf these objects: https://www.zoopla.co.uk/realtime-documentation/#object_tenure
 	const Feudal = 'feudal';
 	const freehold = 'freehold';
 	const Leasehold = 'leasehold';

--- a/tests/SendPropertyTest.php
+++ b/tests/SendPropertyTest.php
@@ -65,7 +65,7 @@ class SendPropertyTest extends TestCase
 
 		$request->property_type = PropertyType::BarnConversion; //enum
 		$request->listed_building_grade = ListedBuildingGrade::CategoryA; //enum
-		$request->tenure = Tenure::Leasehold; //enum
+//		$request->tenure = Tenure::Leasehold; //oneOf object
 
 		//number
 		$request->annual_business_rates = 432;
@@ -81,7 +81,7 @@ class SendPropertyTest extends TestCase
 		$request->buyer_incentives = [BuyerIncentives::HelpToNuy, BuyerIncentives::NewBuy];
 		$request->central_heating = CentralHeating::Full;
 		$request->commercial_use_classes = [CommercialUseClass::A1];
-		$request->council_tax_band = CouncilTaxBand::A;
+//		$request->council_tax_band = CouncilTaxBand::A; //TODO: defined inside local_authority
 		$request->decorative_condition = DecorativeCondition::Average;
 		$request->feature_list = ["test", "test2"];
 		//$request->floor_levels = [FloorLevels::Basement,1];
@@ -191,8 +191,9 @@ class SendPropertyTest extends TestCase
 		$request->google_street_view->heading = 2.32321;
 		$request->google_street_view->pitch = 2.32321;
 
+		// TODO: moved inside tenure >> leasehold object
 		//$request->lease_expiry->expiry_date = date('Y-m-d', strtotime('+ 10 day'));
-		$request->lease_expiry->years_remaining = 2000;
+//		$request->lease_expiry->years_remaining = 2000;
 
 		$request->content = [
 			new Content('https://www.talkwalker.com/images/2020/blog-headers/image-analysis.png', ContentType::Image, 'test'),

--- a/tests/SendPropertyTest.php
+++ b/tests/SendPropertyTest.php
@@ -2,9 +2,11 @@
 
 namespace mehmetbulut\Zoopla\Tests;
 
+use mehmetbulut\Zoopla\Exception\ZooplaValidationException;
 use mehmetbulut\Zoopla\Groups\Content;
 use mehmetbulut\Zoopla\Groups\Description;
 use mehmetbulut\Zoopla\Request\SendProperty;
+use mehmetbulut\Zoopla\Values\Accessibility;
 use mehmetbulut\Zoopla\Values\AreaUnit;
 use mehmetbulut\Zoopla\Values\BillsIncluded;
 use mehmetbulut\Zoopla\Values\BuyerIncentives;
@@ -88,7 +90,7 @@ class SendPropertyTest extends TestCase
 
 		//boolean
 		$request->fishing_rights = false;
-		$request->accessibility = true;
+		$request->accessibility = [Accessibility::WheelchairAccessible, Accessibility::StepFreeAccess, Accessibility::WetRoom, Accessibility::LateralLiving];
 		$request->shared_accommodation = true;
 		$request->basement = true;
 		$request->burglar_alarm = true;
@@ -189,7 +191,12 @@ class SendPropertyTest extends TestCase
 		$this->assertJson($request->getJson());
 		$this->assertNotEmpty($request->getJson());
 
-		$request->validate();
+		try {
+			$request->validate();
+		} catch (ZooplaValidationException $e) {
+			echo '<pre>'; print_r($e->getErrors()); echo '</pre>';
+			$this->fail();
+		}
 
 		//$d = $c->send($request,true,null,false);
 	}

--- a/tests/SendPropertyTest.php
+++ b/tests/SendPropertyTest.php
@@ -90,7 +90,20 @@ class SendPropertyTest extends TestCase
 
 		//boolean
 		$request->fishing_rights = false;
-		$request->accessibility = [Accessibility::WheelchairAccessible, Accessibility::StepFreeAccess, Accessibility::WetRoom, Accessibility::LateralLiving];
+		$request->accessibility = [
+			Accessibility::WheelchairAccessible,
+			Accessibility::StepFreeAccess,
+			Accessibility::WetRoom,
+			Accessibility::LateralLiving,
+			Accessibility::DisabledFeatures,
+			Accessibility::LevelAccess,
+			Accessibility::RampedAccess,
+			Accessibility::LiftAccess,
+			Accessibility::StairLift,
+			Accessibility::WideDorrways,
+			Accessibility::LevelAccessShower,
+			Accessibility::VariableHeightKitchenSurfaces,
+		];
 		$request->shared_accommodation = true;
 		$request->basement = true;
 		$request->burglar_alarm = true;
@@ -195,6 +208,7 @@ class SendPropertyTest extends TestCase
 			$request->validate();
 		} catch (ZooplaValidationException $e) {
 			echo '<pre>'; print_r($e->getErrors()); echo '</pre>';
+
 			$this->fail();
 		}
 

--- a/tests/SendPropertyTest.php
+++ b/tests/SendPropertyTest.php
@@ -5,6 +5,7 @@ namespace mehmetbulut\Zoopla\Tests;
 use mehmetbulut\Zoopla\Exception\ZooplaValidationException;
 use mehmetbulut\Zoopla\Groups\Content;
 use mehmetbulut\Zoopla\Groups\Description;
+use mehmetbulut\Zoopla\Groups\GroundRent;
 use mehmetbulut\Zoopla\Request\SendProperty;
 use mehmetbulut\Zoopla\Values\Accessibility;
 use mehmetbulut\Zoopla\Values\AreaUnit;
@@ -69,7 +70,7 @@ class SendPropertyTest extends TestCase
 		//number
 		$request->annual_business_rates = 432;
 		$request->deposit = 432;
-		$request->ground_rent = 432;
+		$request->ground_rent = new GroundRent(432);
 
 		//date
 		$request->available_from_date = date('Y-m-d');


### PR DESCRIPTION
Updated schemas to 2.3 and api to v2. The only value we send that has changed in v2.3 is `accessibility`, which has been updated. The following have changed but we don't use:
- ground_rent
- tenure
- council_tax_band
- lease_expiry

I've updated the validation to pass but if we want to send these in the future we will need to update the SDK again. I was planing to update all but tenure has become an "enum of objects" and was unsure how to update the model/validation code to handle this. Have opted to just get the bare minimum updated for the sake of upgrade